### PR TITLE
Replace nodes in second pass after loading variables.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "metalab/standard"
+    "metalab/base"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -19,48 +19,80 @@ module.exports = {
 
 ```css
 /* foo.css */
-~foo: "./foo.js"
+~foo: "./foo.js";
 
 .body {
-  color: foo.color;
+  color: ~foo.color;
 }
 ```
 
-With [webpack]:
+```javascript
+import constants from 'postcss-require';
+import postcss from 'webpack-config-postcss';
+import partial from 'webpack-partial';
+
+// webpack.config.babel.js
+export default partial({
+  // ...
+}, postcss(webpack) {
+  return [constants()];
+});
+```
+
+Advanced usage with [webpack] gives you access to [webpack] resolves, loaders and more:
 
 ```javascript
-// webpack.config.babel.js
+// foo.js
 export default {
-  // ...
-  postcss() {
-    return [
-      constants({
-        require: (request, _, done) => {
-          this.loadModule(request, (err, source) => {
-            if (err) {
-              done(err);
-            } else {
-              let result = null;
-              try {
-                result = this.exec(source, request);
-                // interop for ES6 modules
-                if (result.__esModule && result.default) {
-                  result = result.default;
-                }
-              } catch (e) {
-                done(e);
-                return;
-              }
-              // Don't need to call `this.addDependency` since the
-              // `loadModule` function takes care of it.
-              done(null, result);
-            }
-          });
-        },
-      })
-    ]
-  }
+  color: 'green'
 }
+```
+
+```css
+/* foo.css */
+~foo: "~/some-module/foo";
+
+.body {
+  color: ~foo.color;
+}
+```
+
+```javascript
+import constants from 'postcss-require';
+import postcss from 'webpack-config-postcss';
+import partial from 'webpack-partial';
+
+// webpack.config.babel.js
+export default partial({
+  // ...
+},  postcss(webpack) {
+  return [
+    constants({
+      require: (request, _, done) => {
+        webpack.loadModule(request, (err, source) => {
+          if (err) {
+            done(err);
+          } else {
+            let result = null;
+            try {
+              result = this.exec(source, request);
+              // interop for ES6 modules
+              if (result.__esModule && result.default) {
+                result = result.default;
+              }
+            } catch (e) {
+              done(e);
+              return;
+            }
+            // Don't need to call `this.addDependency` since the
+            // `loadModule` function takes care of it.
+            done(null, result);
+          }
+        });
+      },
+    })
+  ]
+})
 ```
 
 TODO:

--- a/package.json
+++ b/package.json
@@ -16,10 +16,13 @@
     "postcss": ">=5"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.2",
-    "babel-preset-metalab": "^0.1.1",
-    "eslint": "^1.8.0",
-    "eslint-config-metalab": "^0.3.0",
-    "postcss": "^5.0.11"
+    "babel-cli": "^6.4.5",
+    "babel-preset-metalab": "^0.2.0",
+    "eslint": "^1.10.3",
+    "eslint-config-metalab": "^2.0.0-beta.2",
+    "eslint-plugin-filenames": "^0.2.0",
+    "eslint-plugin-import": "^0.12.1",
+    "eslint-plugin-react": "^3.16.0",
+    "postcss": "^5.0.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/require.js",
   "scripts": {
     "lint": "./node_modules/.bin/eslint --ignore-path .gitignore .",
-    "prepublish": "./node_modules/.bin/babel -s inline -d dist src/",
+    "prepublish": "./node_modules/.bin/babel -s -d dist src/",
     "test": "npm run lint"
   },
   "dependencies": {

--- a/src/require.js
+++ b/src/require.js
@@ -1,9 +1,9 @@
 import postcss from 'postcss';
 import nodepath from 'path';
 import resolve from 'resolve';
-import { get } from 'object-path';
+import {get} from 'object-path';
 
-function defaultRequire(path, options, done) {
+const defaultRequire = (path, options, done) => {
   resolve(path, options, (err, res) => {
     if (err) {
       done(err);
@@ -19,14 +19,14 @@ function defaultRequire(path, options, done) {
       done(null, mod);
     }
   });
-}
+};
 
-export default postcss.plugin('postcss-require', function({
+export default postcss.plugin('postcss-require', ({
   require = defaultRequire,
-} = {}) {
+} = {}) => {
   const constants = { };
 
-  function load(name, path, directory, done) {
+  const load = (name, path, directory, done) => {
     require(JSON.parse(path), {
       basedir: nodepath.dirname(directory),
     }, (err, data) => {
@@ -37,30 +37,31 @@ export default postcss.plugin('postcss-require', function({
         done();
       }
     });
-  }
+  };
 
-  function replace(str) {
+  const replace = (str) => {
     return str.replace(/~([\w]+)\.(.+)/g, (_, module, path) => {
       return get(constants[module], path);
     });
-  }
+  };
 
-  function isRelevant(value) {
-    return value.indexOf('~') > -1;
-  }
+  const isRelevant = (value) => {
+    return value.indexOf('~') >= 0;
+  };
 
-  return function(css) {
+  return (css) => {
     return new Promise((resolve, reject) => {
       let count = 0;
-      function check() {
+      const check = () => {
         if (count === 0) {
           resolve();
         }
-      }
-      css.walk(node => {
+      };
+      css.walk((node) => {
         if (node.type === 'decl' && isRelevant(node.prop)) {
+          const x = node.prop.slice(1);
           ++count;
-          load(node.prop.slice(1), node.value, node.source.input.from, err => {
+          load(x, node.value, node.source.input.from, (err) => {
             --count;
             if (err) {
               reject(err);

--- a/src/require.js
+++ b/src/require.js
@@ -54,6 +54,15 @@ export default postcss.plugin('postcss-require', ({
       let count = 0;
       const check = () => {
         if (count === 0) {
+          css.walk((node) => {
+            if (node.type === 'decl' && isRelevant(node.value)) {
+              node.value = replace(node.value);
+            } else if (node.type === 'rule' && isRelevant(node.selector)) {
+              node.selector = replace(node.selector);
+            } else if (node.type === 'atrule' && isRelevant(node.params)) {
+              node.params = replace(node.params);
+            }
+          });
           resolve();
         }
       };
@@ -70,12 +79,6 @@ export default postcss.plugin('postcss-require', ({
             }
           });
           node.remove();
-        } else if (node.type === 'decl' && isRelevant(node.value)) {
-          node.value = replace(node.value);
-        } else if (node.type === 'rule' && isRelevant(node.selector)) {
-          node.selector = replace(node.selector);
-        } else if (node.type === 'atrule' && isRelevant(node.params)) {
-          node.params = replace(node.params);
         }
       });
       check();


### PR DESCRIPTION
Before there was a bit of a race condition with regards to async resolvers and loaders – if a resolver didn't resolve synchronously the walk would continue and variables would get replaced with `undefined` before their real values were actually loaded. Now there are two separate phases – one for the resolution and one for the replacement, ensuring all values are resolved before they're replaced.
